### PR TITLE
Add tests

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: fiximports
+  name: Fix imports
+  entry: fiximports
+  language: python
+  types: [python]

--- a/fiximports/fiximports.py
+++ b/fiximports/fiximports.py
@@ -126,6 +126,13 @@ class FixImports(object):
                         for imp in imports:
                             newlines.append("from {} import {}".format(module, imp))
                         continue
+
+                    match = self._regexImport.match(line)
+                    if match:
+                        modules = [s.strip() for s in match.group(1).split(",")]
+                        for module in modules:
+                            newlines.append("import {}".format(module))
+                        continue
                 else:
                     maybeEndGroup()
                 newlines.append(line)

--- a/fiximports/fiximports.py
+++ b/fiximports/fiximports.py
@@ -106,17 +106,17 @@ class FixImports(object):
                 self.group_start = None
 
         if splitImportStatements:
-            iter = six.next(lines)
+            it_lines = iter(lines)
             while True:
                 line = line.strip()
                 try:
-                    line = six.next()
+                    line = six.next(it_lines)
                 except StopIteration:
                     break
                 if self.isImportLine(line):
                     # join any continuation lines (\\)
                     while line[-1] == '\\':
-                        line = line[:-1] + six.next()
+                        line = line[:-1] + it_lines.next()
                     if self.group_start is None:
                         self.group_start = len(newlines)
 

--- a/fiximports/fiximports.py
+++ b/fiximports/fiximports.py
@@ -88,7 +88,7 @@ class FixImports(object):
         '''
         lines = data.split("\n")
         res = True
-        for cur_line_nb, line in enumerate(lines):
+        for cur_line_nb, line in enumerate(lines, 1):
             if not self.analyzeLine(filename, line, cur_line_nb):
                 if not self.isBadLineFixable(line):
                     res = False
@@ -108,7 +108,6 @@ class FixImports(object):
         if splitImportStatements:
             it_lines = iter(lines)
             while True:
-                line = line.strip()
                 try:
                     line = six.next(it_lines)
                 except StopIteration:
@@ -116,27 +115,26 @@ class FixImports(object):
                 if self.isImportLine(line):
                     # join any continuation lines (\\)
                     while line[-1] == '\\':
-                        line = line[:-1] + it_lines.next()
+                        line = line[:-1] + six.next(it_lines)
                     if self.group_start is None:
                         self.group_start = len(newlines)
 
-                    if self.isBadLineFixable(line):
-                        match = self._regexFromImport.match(line)
-                        if match:
-                            module = match.group(1)
-                            imports = [s.strip() for s in match.group(2).split(",")]
-                            for imp in imports:
-                                newlines.append("from {} import {}".format(module, imp))
-                            continue
+                    match = self._regexFromImport.match(line)
+                    if match:
+                        module = match.group(1)
+                        imports = [s.strip() for s in match.group(2).split(",")]
+                        for imp in imports:
+                            newlines.append("from {} import {}".format(module, imp))
+                        continue
                 else:
                     maybeEndGroup()
                 newlines.append(line)
+            lines = newlines
 
         maybeEndGroup()
 
         # sort each group
         if sortImportStatements:
-            lines = newlines
             for start, end in self.groups:
                 lines[start:end] = sorted(lines[start:end], key=self.importOrder)
 

--- a/fiximports/fiximports.py
+++ b/fiximports/fiximports.py
@@ -172,22 +172,27 @@ def main():
 
     parser = argparse.ArgumentParser(description='Fix Python Import Statements')
     parser.add_argument('filename', metavar='FILENAME',
-                        help='Path or glob of Python files to fix')
+                        help='Path of Python files to fix', nargs='+')
 
     args = parser.parse_args()
-    filename = args.filename
 
-    with open(filename, 'r') as filedesc:
-        data = filedesc.read()
-    res, content = FixImports().sortImportGroups(filename, data)
-    if not res:
-        return 1
+    errors = False
+    for filename in args.filename:
+        with open(filename, 'r') as filedesc:
+            data = filedesc.read()
 
-    with open(filename, 'w') as filedesc:
-        filedesc.write(content)
-    if data != content:
-        print("import successfully reordered for file: %s" % (filename))
-    return 0
+        res, content = FixImports().sortImportGroups(filename, data)
+        if not res:
+            errors = True
+            continue
+
+        with open(filename, 'w') as filedesc:
+            filedesc.write(content)
+        if data != content:
+            print("import successfully reordered for file: %s" % (filename))
+
+    return 1 if errors else 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_fiximports.py
+++ b/tests/test_fiximports.py
@@ -56,6 +56,12 @@ class TestFixImport(unittest.TestCase):
 
     def test_split_import(self):
         self.assertSortImports(
+            "import b, a\n",
+            "import a\nimport b\n",
+        )
+
+    def test_split_from_import(self):
+        self.assertSortImports(
             "from m import b, c\n",
             "from m import b\nfrom m import c\n",
         )

--- a/tests/test_fiximports.py
+++ b/tests/test_fiximports.py
@@ -1,7 +1,119 @@
 import unittest
 
+from unittest import mock
+
+from fiximports.fiximports import FixImports
+from fiximports.fiximports import main
+
+example_input = """\
+from any_module import d, f
+from other_module import z, x
+from any_module import b, e
+from any_module import a, \\
+                       c
+
+from a_module_that_should_be import at, after, all_others
+"""
+
+example_expected = """\
+from any_module import a
+from any_module import b
+from any_module import c
+from any_module import d
+from any_module import e
+from any_module import f
+from other_module import x
+from other_module import z
+
+from a_module_that_should_be import after
+from a_module_that_should_be import all_others
+from a_module_that_should_be import at
+"""
 
 class TestFixImport(unittest.TestCase):
+    maxDiff = None
 
-    def testSimple(self):
-        pass
+    def assertSortImports(self, data, expected, **kwargs):
+        kwargs.setdefault("filename", "test.py")
+        success, output = FixImports().sortImportGroups(data=data, **kwargs)
+        self.assertTrue(success)
+        self.assertEqual(expected, output)
+
+    def test_readme_example(self):
+        self.assertSortImports(example_input, example_expected)
+
+    def test_sort_names(self):
+        self.assertSortImports(
+            "import b\nimport a\n",
+            "import a\nimport b\n",
+        )
+
+    def test_sort_modules(self):
+        self.assertSortImports(
+            "from b import x\nfrom a import b\nfrom b import a\n",
+            "from a import b\nfrom b import a\nfrom b import x\n",
+        )
+
+    def test_split_import(self):
+        self.assertSortImports(
+            "from m import b, c\n",
+            "from m import b\nfrom m import c\n",
+        )
+
+    def test_statements_not_split(self):
+        self.assertSortImports(
+            "import os; import sys\n",
+            "import os; import sys\n",
+        )
+
+    def test_reject_parenthesis(self):
+        success, _ = FixImports().sortImportGroups("parens.py", "from m import (a, b)\n")
+        self.assertFalse(success)
+
+    @mock.patch("sys.argv", ["fiximports"])
+    def test_cli_without_arguments(self):
+        with self.assertRaises(SystemExit) as e:
+            main()
+        self.assertEqual(e.exception.code, 2)
+
+    @mock.patch("sys.argv", ["fiximports", "--help"])
+    def test_cli_help(self):
+        with self.assertRaises(SystemExit) as e:
+            main()
+        self.assertEqual(e.exception.code, 0)
+
+    @mock.patch("sys.argv", ["fiximports", "one.py", "two.py"])
+    @mock.patch("fiximports.fiximports.open")
+    @mock.patch("fiximports.fiximports.FixImports")
+    def test_cli_filenames(self, fixer, mock_open):
+        mocked_input = "# Mocked input\n"
+        mocked_output = "# Mocked output\n"
+
+        sort_imports = fixer.return_value.sortImportGroups
+        sort_imports.return_value = (True, mocked_output)
+
+        mock.mock_open(mock_open, mocked_input)
+
+        rv = main()
+        self.assertEqual(rv, 0)
+
+        mock_open.assert_any_call("one.py", "r")
+        mock_open.assert_any_call("two.py", "r")
+        sort_imports.assert_any_call("one.py", mocked_input)
+        sort_imports.assert_any_call("two.py", mocked_input)
+
+        mock_open.assert_any_call("one.py", "w")
+        mock_open.assert_any_call("two.py", "w")
+        mock_open().write.assert_any_call(mocked_output)
+
+    @mock.patch("sys.argv", ["fiximports", "one.py"])
+    @mock.patch("fiximports.fiximports.open")
+    def test_cli_errors(self, mock_open):
+        mocked_input = "from m import (a, b)\n"
+        mock.mock_open(mock_open, mocked_input)
+
+        rv = main()
+        self.assertEqual(rv, 1)
+
+        mock_open.assert_any_call("one.py", "r")
+        mock_open().write.assert_not_called()


### PR DESCRIPTION
While working on [Guake #2031](https://github.com/Guake/guake/issues/2031) I noticed that there were no tests for this tool, so I wrote some.

This MR also includes the work I did to use this tool as a pre-commit hook, and the [commit](https://github.com/gsemet/fiximports/commit/f1b2d95718f4148993d97fbdd46944c6ee56ae99) tagged [0.1.18](https://github.com/gsemet/fiximports/releases/tag/0.1.18), which currently does not belong to any branch.